### PR TITLE
This change intentionally excludes the following from the dump:

### DIFF
--- a/functions.sh
+++ b/functions.sh
@@ -126,6 +126,7 @@ function do_dump() {
     for onedb in $DB_NAMES; do
       for excluded in $EXCLUSION_LIST; do
         [[ $onedb != $excluded ]] && STRICT_DB_LIST+=($onedb)
+        [ $? -ne 0 ] && return 1
       done
     done
 
@@ -133,7 +134,6 @@ function do_dump() {
     for strict_db in $STRICT_DB_LIST; do
       mysqldump -h $DB_SERVER -P $DB_PORT $DBUSER $DBPASS --databases ${strict_db} $MYSQLDUMP_OPTS > $workdir/${strict_db}_${now}.sql
       [ $? -ne 0 ] && return 1
-      done
     done
   else
     # just a single command


### PR DESCRIPTION
### Summary
This change intentionally skips the following from the dump:
```
- information_schema,
- mysql,
- performance_schema
```
#### Reason

When running dumps on a managed db like [Maria](https://azure.microsoft.com/en-us/services/mariadb/) You may not be privileged enough to run queries like `SELECT` on specific tables the excluded list, breaking the process.
It is also not advisable to give your backup user Super privileges even though you can afford to.
This may not be the best fix, but it does the job. Please PR / Issue for suggestions / recommendations.